### PR TITLE
Fix equating comparisons between MPANs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-**Description:**
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-
-**JIRA:**
-Please include a link to the issue on JIRA if applicable.
+* Please include a summary of the change and which issue is fixed.
+* Please also include relevant motivation and context.
+* List any dependencies that are required for this change.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ there.
 
 * Bugfix: The `is_valid()` shortcut now returns `False` when an unparseable
   MPAN is passed in, rather than exploding with an `InvalidMpanError`.
+* Bugfix: Comparing two identical MPAN objects now returns boolean `True`
 * Added lots more documentation to the README.
 
 

--- a/mpan.py
+++ b/mpan.py
@@ -365,6 +365,11 @@ class MPAN:
     def __repr__(self):
         return str(self)
 
+    def __eq__(self, other):
+        if not isinstance(other, MPAN):
+            return False
+        return str(self) == str(other)
+
     @property
     def is_short(self) -> bool:
         return self.profile_class is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mpan"
-version = "1.0.2"
+version = "1.0.3"
 description = "A parsing library for the UK's MPAN energy standard"
 authors = ["Limejump Developers <opensource@limejump.com>"]
 license = "MIT"

--- a/tests/test_mpan.py
+++ b/tests/test_mpan.py
@@ -156,6 +156,20 @@ class MPANTestCase(TestCase):
             repr(MPAN("018011002099999999386")), "018011002099999999386"
         )
 
+    def test___eq__with_valid_mpans(self):
+        for string in get_valid_mpans():
+            self.assertEqual(MPAN(string), MPAN(string))
+
+    def test___eq__with_invalid_mpans(self):
+        for string in INVALID:
+            self.assertEqual(MPAN(string), MPAN(string))
+
+    def test___eq__with_foreign_objects(self):
+        mpan_string = "108011002099999999386"
+        self.assertNotEqual(MPAN(mpan_string), mpan_string)
+        self.assertNotEqual(MPAN(mpan_string), 108011002099999999386)
+        self.assertNotEqual(MPAN(mpan_string), "twelve")
+
     def test_parsing_long_pass(self):
 
         mpan = MPAN("018011002099999999386")


### PR DESCRIPTION
> *I'm undecided as to whether this should be a bump from `1.0.2` to `1.0.3` or to `1.1.0` on account of the API sort-of-change.*

I noticed today that `MPAN(string) ≠ MPAN(string)` on account of the fact that I never implemented `__eq__()` on the `MPAN` class.  This PR fixes that.